### PR TITLE
Add elm-lang/html to dependencies

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -32,6 +32,7 @@
         "elm-community/result-extra": "2.2.0 <= v < 3.0.0",
         "elm-community/string-extra": "1.4.0 <= v < 2.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0",
         "hickscorp/elm-bigint": "1.0.1 <= v < 2.0.0",


### PR DESCRIPTION
Add `elm-lang/html` to dependencies list in `elm-packages.json`

Reason:
Was shown error messages below when try to load `Main.Elm` in `./examples/simple`  
```
I cannot find module 'Html'.

Module 'Main' is trying to import it.

Potential problems could be:
  * Misspelled the module name
  * Need to add a source directory or new dependency to elm-package.json
```