### PR TITLE
Various bugfixes

### DIFF
--- a/src/Abi/Decode.elm
+++ b/src/Abi/Decode.elm
@@ -223,7 +223,8 @@ string =
         \(Tape original altered) ->
             take64 altered
                 |> buildBytes original
-                |> Result.map (StringExtra.break 2 >> List.filter (not << String.isEmpty))
+                |> Result.map (StringExtra.break 2)
+                |> Result.map (List.filter (String.isEmpty >> not))
                 |> Result.andThen (List.map Hex.fromString >> ResultExtra.combine)
                 |> Result.andThen UTF8.toString
                 |> Result.map (newTape original altered)

--- a/src/Abi/Decode.elm
+++ b/src/Abi/Decode.elm
@@ -223,7 +223,7 @@ string =
         \(Tape original altered) ->
             take64 altered
                 |> buildBytes original
-                |> Result.map (StringExtra.break 2)
+                |> Result.map (StringExtra.break 2 >> List.filter (not << String.isEmpty))
                 |> Result.andThen (List.map Hex.fromString >> ResultExtra.combine)
                 |> Result.andThen UTF8.toString
                 |> Result.map (newTape original altered)

--- a/src/Abi/Encode.elm
+++ b/src/Abi/Encode.elm
@@ -746,5 +746,6 @@ tillMod64 n =
 stringToHex : String -> String
 stringToHex strVal =
     UTF8.toBytes strVal
-        |> List.map Hex.toString
+        |> List.map
+            (Hex.toString >> String.padLeft 2 '0')
         |> String.join ""

--- a/src/Eth/Utils.elm
+++ b/src/Eth/Utils.elm
@@ -112,10 +112,10 @@ toAddress str =
     -- Address is always stored without "0x"
     if String.length noZeroX == 64 && String.all ((==) '0') emptyZerosInBytes32 then
         if isUpperCaseAddress bytes32Address || isLowerCaseAddress bytes32Address then
-            Ok <| Internal.Address bytes32Address
+            Ok <| Internal.Address <| String.toLower bytes32Address
 
         else if isChecksumAddress bytes32Address then
-            Ok <| Internal.Address bytes32Address
+            Ok <| Internal.Address <| String.toLower bytes32Address
 
         else
             Err <| "Given address " ++ quote str ++ " failed the EIP-55 checksum test."
@@ -127,10 +127,10 @@ toAddress str =
         Err <| "Given address " ++ quote str ++ " contains invalid hex characters."
 
     else if isUpperCaseAddress noZeroX || isLowerCaseAddress noZeroX then
-        Ok <| Internal.Address noZeroX
+        Ok <| Internal.Address <| String.toLower noZeroX
 
     else if isChecksumAddress noZeroX then
-        Ok <| Internal.Address noZeroX
+        Ok <| Internal.Address <| String.toLower noZeroX
 
     else
         Err <| "Given address " ++ quote str ++ " failed the EIP-55 checksum test."


### PR DESCRIPTION
Recently I ran into a bug where comparing two addresses for equality would return false even if they were the same address. It turned out that elm-ethereum had been storing some addresses with some uppercase letters, and others with all lowercase. This is my quick fix.